### PR TITLE
Changed track_max_not_mask default option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Eclipse #
+/.classpath
+/.project
+/.settings/
+
+# Maven #
+/target/
+
+# IntelliJ
+*.iml
+/.idea/
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@
 *.iml
 /.idea/
 
+out
 .DS_Store

--- a/carpet_ICS_jru_v1.java
+++ b/carpet_ICS_jru_v1.java
@@ -11,6 +11,7 @@ import ij.gui.*;
 import java.awt.*;
 import ij.plugin.*;
 import jalgs.*;
+import jalgs.jfft.autocorr;
 import jguis.*;
 
 public class carpet_ICS_jru_v1 implements PlugIn {

--- a/track_max_not_mask_jru_v1.java
+++ b/track_max_not_mask_jru_v1.java
@@ -39,6 +39,10 @@ public class track_max_not_mask_jru_v1 implements PlugIn, DialogListener,  track
 		fracstat=jstatistics.stats[gd5.getNextChoiceIndex()];
 		threshfraction=2.0f;
 		if(fracstat.equals("Max")) threshfraction=0.5f;
+
+		if (fracstat.equals("Identity")) {
+			threshfraction = (float)imp.getProcessor().getStatistics().max;
+		}
 		fb=new findblobs(width,height,new float[]{0.0f,10000.0f,0.0f,1000.0f,10,5,10});
 		float[] criteria=get_criteria(imp,fb);
 		if(criteria==null) return;


### PR DESCRIPTION
@jayunruh 
If identity is selected as the statistic, I modified the plugin to use the maximum of the current slice as the threshold fraction.

```
if (fracstat.equals("Identity")) {
            threshfraction = (float)imp.getProcessor().getStatistics().max;
        }
```

Additionally, I added a .gitignore file so any unwanted files could be ignored by git.
